### PR TITLE
Allow for multi task option configuration

### DIFF
--- a/tasks/grunt-cloudfront.js
+++ b/tasks/grunt-cloudfront.js
@@ -23,7 +23,7 @@ module.exports = function(grunt) {
   grunt.registerMultiTask('cloudfront', 'Cloudfront cache invalidating task', function() {
     var done = this.async(),
         options = this.options(),
-        version = options.version
+        version = options.version,
         data = _.omit(this.data, 'options');
 
     AWS.config.update({


### PR DESCRIPTION
This allows options to be configured per task. Had to make a local fork to allow this for myself and thought it was worth sending a pull request in case others need this functionality like I did.

``` javascript
cloudfront: {
  options: {
    region: 'us-east-1'
    listInvalidations: true
    credentials: amazonCreds
  },
  dev: {
    options: {
      distributionId: '** DEV KEY **'
    },
    CallerReference: Date.now().toString(),
    Paths: {
      Quantity: 1,
      Items: [ '/index.html' ]
    }
  live: {
    options: {
      distributionId: '** LIVE KEY **'
    },
    CallerReference: Date.now().toString(),
    Paths: {
      Quantity: 1,
      Items: [ '/index.html' ]
    }
  }
}
```

Great grunt task
