### PR TITLE
changing the shutdown log level to debug

### DIFF
--- a/tasks/grunt-cloudfront.js
+++ b/tasks/grunt-cloudfront.js
@@ -16,7 +16,7 @@ module.exports = function(grunt) {
       _ = require("underscore");
 
   process.on('SIGINT', function() {
-    grunt.log.writeln('').write('Shutting down the amazon Cloudfront task...').ok();
+    grunt.debug.writeln('').write('Shutting down the amazon Cloudfront task...').ok();
     process.exit();
   });
 


### PR DESCRIPTION
It seemed weird to me that when I would have a grunt watch and would close it using ctrl+c, a log of the cloudfront process shutting down would come up, even if the task was never actually ran.  At that point, I don't think the process is even alive (an conditional check might be more appropriate) and I simply wanted to remove the log to not confuse any other developers.
