### PR TITLE
let aws-sdk handle the credential handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,13 @@ grunt.initConfig({
 });
 ```
 
+### AWS Region
+You can store your AWS region in the following environment variable and it will be used if available:
+
+```json
+AWS_REGION
+```
+
 ### AWS Credentials
 You should store your AWS credentials outside of source control. They will be loaded from the following environment variables if available:
 
@@ -75,6 +82,6 @@ Or you can store them in a git ignored credential file which looks like this:
 * May 14, 2013 - __0.1.0__ First release
 
 ## License
-[Florent Lamoureux](http://twitter.com/flrent)  
-Licensed under the MIT license.  
+[Florent Lamoureux](http://twitter.com/flrent)
+Licensed under the MIT license.
 Copyright (c) 2013 - [http://www.payrollhero.com](PayrollHero.com)

--- a/tasks/grunt-cloudfront.js
+++ b/tasks/grunt-cloudfront.js
@@ -26,11 +26,13 @@ module.exports = function(grunt) {
         version = options.version,
         data = _.omit(this.data, 'options');
 
+    options.credentials = options.credentials || {};
     AWS.config.update({
       region: options.region,
-      accessKeyId: (process.env.AWS_ACCESS_KEY_ID || options.credentials.accessKeyId),
-      secretAccessKey: (process.env.AWS_SECRET_ACCESS_KEY || options.credentials.secretAccessKey),
+      accessKeyId: options.credentials.accessKeyId,
+      secretAccessKey: options.credentials.secretAccessKey,
     });
+
     var CloudFront = new AWS.CloudFront();
 
     if(!_.isUndefined(version)) {


### PR DESCRIPTION
`aws-sdk` handles the credential environment-variables, so there is no need to do it in this plugin!

i also added the note about the `AWS_REGION` environment variable!
