### PR TITLE
Fix: Fatal error: Cannot read property 'length' of null

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "readmeFilename": "README.md",
   "dependencies": {
     "grunt": "~0.4.1",
-    "aws-sdk": "~1.0.0",
+    "aws-sdk": "~2.0.0",
     "moment": "~2.0.0",
     "underscore": "~1.4.4"
   }


### PR DESCRIPTION
Updated package.json `aws-sdk` dependency from v1.x -> v2.x.

This should resolve https://github.com/flrent/grunt-cloudfront/issues/16